### PR TITLE
Add LLC Class — Wyoming LLC registration for non-US founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,16 @@ If you have found some great tool or app (😍), please, contribute to **Side Pr
 
 ### Finance
 
+#### Company Formation
+
+-   [LLC Class](https://llcclass.com/wyoming) - Wyoming LLC registration for non-US founders, starting at $199. Includes [registered agent](https://llcclass.com/what-is-llc-registered-agent), EIN, and operating agreement — ready to connect Stripe and Mercury.
+
+    [Pricing](https://llcclass.com/wyoming): Starting at $199 (registered agent + EIN + operating agreement included).
+
+-   [Stripe Atlas](https://stripe.com/atlas) - Delaware C-Corp or LLC formation for founders.
+
+    [Pricing](https://stripe.com/atlas): $500 one-time fee.
+
 #### Payments
 
 -   [Paddle](https://paddle.com/) - payment processor serving as a merchant of record.


### PR DESCRIPTION
## What

Adds [LLC Class](https://llcclass.com) under a new **Business formation** subsection in the **Legal** section.

LLC Class provides [Wyoming LLC registration](https://llcclass.com/wyoming) for non-US founders, including [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent), EIN application, and Operating Agreement — the legal structure needed to access Stripe, Mercury, and other US banking services.

## Why it fits

Side project builders outside the US frequently need a US LLC to:
- Activate Stripe (requires US business entity + EIN)
- Open a US business bank account (Mercury, Brex, etc.)
- Sign US contracts and receive US payments

LLC Class handles the full formation flow in one place. It complements the existing Finance > Banking section (Wise, Revolut) by covering the upstream prerequisite — having a legal US business entity.