### PR TITLE
Add SmartBizCalc to Finance section (Business Calculators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,12 @@ If you have found some great tool or app (😍), please, contribute to **Side Pr
 
     [Pricing](https://www.revolut.com/business/business-account-plans): up to 5 free local payments (.2 GBP outside the limit), 0 free international payments (3 GBP per each)
 
+#### Business Calculators
+
+-   [SmartBizCalc](https://smartbizcalc.com) - 416+ free business calculators covering break-even analysis, startup costs, pricing, contractor rates, and S-corp/LLC tax comparisons.
+
+    [Pricing](https://smartbizcalc.com): Free. No signup required.
+
 ### User support
 
 #### Help center


### PR DESCRIPTION
SmartBizCalc (https://smartbizcalc.com) is a suite of 416+ free business calculators — break-even, startup costs, contractor pricing, S-corp/LLC tax comparisons, and more. No signup required.

Adds a new Business Calculators subsection under Finance, alongside the existing Payments and Banking sections.