### PR TITLE
Add Financial Calculators subsection under Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,12 @@ If you have found some great tool or app (😍), please, contribute to **Side Pr
 
     [Pricing](https://www.revolut.com/business/business-account-plans): up to 5 free local payments (.2 GBP outside the limit), 0 free international payments (3 GBP per each)
 
+#### Financial Calculators
+
+-   [SmartBizCalc](https://smartbizcalc.com) — 430+ free business calculators covering payroll taxes, break-even analysis, startup costs, profit margins, S-corp vs LLC savings, and contractor pricing.
+
+    Pricing: Free, no signup required.
+
 #### Business Calculators
 
 -   [SmartBizCalc](https://smartbizcalc.com) - 416+ free business calculators covering break-even analysis, startup costs, pricing, contractor rates, and S-corp/LLC tax comparisons.

--- a/README.md
+++ b/README.md
@@ -463,6 +463,12 @@ If you have found some great tool or app (😍), please, contribute to **Side Pr
 
     [Pricing](https://www.revolut.com/business/business-account-plans): up to 5 free local payments (.2 GBP outside the limit), 0 free international payments (3 GBP per each)
 
+#### Business Calculators
+
+-   [SmartBizCalc](https://smartbizcalc.com) - 416+ free business calculators covering break-even analysis, startup costs, pricing, contractor rates, and S-corp/LLC tax comparisons.
+
+    [Pricing](https://smartbizcalc.com): Free. No signup required.
+
 ### User support
 
 #### Help center


### PR DESCRIPTION
## Summary

Adds a **Financial Calculators** subsection to the Finance section with [SmartBizCalc](https://smartbizcalc.com) — a collection of 430+ free business calculators specifically useful for side project founders and indie hackers:

- Payroll tax calculator (employer tax burden)
- Break-even analysis calculator
- Startup cost estimator
- Profit margin calculator (by industry)
- S-corp vs LLC tax savings calculator
- Contractor pricing and markup calculator

All tools are free with no signup required, making them a natural fit alongside the existing free-tier tools in this list.